### PR TITLE
fix: Fix LIC8,13

### DIFF
--- a/decide/src/main/java/com/decide/LICConditions.java
+++ b/decide/src/main/java/com/decide/LICConditions.java
@@ -251,8 +251,15 @@ public class LICConditions {
             Point C = points[i + A_PTS + B_PTS];
 
             double radius = Point.circumradius(A, B, C);
-            if (radius > RADIUS1)
-                return true;
+            if (radius > RADIUS1) {
+                if (Double.isInfinite(radius)) {
+                    radius = Point.circleLineSegment(A, B, C);
+                    if (radius > RADIUS1){
+                        return true;
+                    }
+                }
+                else return true;
+            }
         }
         return false;
     }
@@ -393,9 +400,17 @@ public class LICConditions {
 
             double radius = Point.circumradius(A, B, C);
             if (radius > RADIUS1)
-                cond1 = true;
+                if (Double.isInfinite(radius)) {
+                    radius = Point.circleLineSegment(A, B, C);
+                    if (radius > RADIUS1) cond1 = true;
+                }
+                else cond1 = true;
             if (radius <= RADIUS2)
-                cond2 = true;
+                if (Double.isInfinite(radius)) {
+                    radius = Point.circleLineSegment(A, B, C);
+                    if (radius <= RADIUS2) cond2 = true;
+                }
+                else cond2 = true;
             if (cond1 && cond2)
                 return true;
         }

--- a/decide/src/test/java/LICConditionsTest.java
+++ b/decide/src/test/java/LICConditionsTest.java
@@ -331,7 +331,7 @@ public class LICConditionsTest {
                                 "Expected IllegalArgumentException to be thrown for A_PTS + B_PTS > NUMPOINTS - 3");
                 assertEquals("A_PTS + B_PTS must be less than or equal to NUMPOINTS - 3.", exception2.getMessage());
 
-                // Test Case 6: Points are collinear -> satisfy the condition
+                // Test Case 6: Points are on a line and can be contained in circle with radius 10
                 Point[] pointsCase6 = {
                                 new Point(0, 0),
                                 new Point(1, 0),
@@ -344,9 +344,9 @@ public class LICConditionsTest {
                 double RADIUS1Case6 = 10.0;
                 int numPoints6 = pointsCase6.length;
 
-                assertTrue(
+                assertFalse(
                                 LICConditions.LIC8(pointsCase6, A_PTS6, B_PTS6, RADIUS1Case6, numPoints6),
-                                "Expected LIC8 to return true for collinear points that cannot be contained in a circle");
+                                "Expected LIC8 to return false for collinear points that can be contained in a circle");
         }
 
         @Test


### PR DESCRIPTION
Used the circleLineSegment() method from the point class to fix previous mistake in LIC 8 and 13